### PR TITLE
Date Formatting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _Patch reporting simplified_
 
-![](https://img.shields.io/badge/license-apache_2.0-blue)&nbsp;![](https://img.shields.io/badge/python-3.9%2B-blue)&nbsp;![](https://github.com/liquidz00/patcher/actions/workflows/test.yaml/badge.svg)
+![](https://img.shields.io/badge/license-apache_2.0-blue)&nbsp;![](https://img.shields.io/badge/python-3.9%2B-blue)&nbsp;![](https://github.com/liquidz00/patcher/actions/workflows/test.yaml/badge.svg)&nbsp;![](https://img.shields.io/github/v/release/liquidz00/Patcher?color=purple)
 
 
 Patcher leverages the Jamf Pro API to fetch patch management data and generate comprehensive reports in both Excel and PDF formats. It simplifies tracking and reporting on software update compliance across macOS devices managed through Jamf Pro.
@@ -42,7 +42,7 @@ The installer script will guide you through setting up your Jamf Pro instance de
 ### Usage
 After installation, you can generate reports by running the main script. You can specify the output directory for the reports and choose to generate PDF reports alongside Excel files.
 ```shell
-python patcher.py --path /path/to/output/directory [--pdf]
+python3 patcher.py --path /path/to/output/directory [--pdf]
 ```
 - The `--path` option specifies the directory where the reports will be saved.
 - The optional `--pdf` flag indicates if PDF reports should be generated in addition to Excel files.

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -38,8 +38,10 @@ logthis = logger.setup_child_logger("patcher", __name__)
 
 
 class PDF(FPDF):
-    def __init__(self, orientation="L", unit="mm", format="A4"):
+    def __init__(self, orientation="L", unit="mm", format="A4", date_format="%B %d %Y"):
         super().__init__(orientation=orientation, unit=unit, format=format)
+        self.date_format = date_format
+
         self.add_font(FONT_NAME, "", FONT_REGULAR_PATH)
         self.add_font(FONT_NAME, "B", FONT_BOLD_PATH)
 
@@ -54,7 +56,11 @@ class PDF(FPDF):
         # Month/Year in light
         self.set_font("Assistant", "", 18)
         self.cell(
-            0, 10, datetime.now().strftime("%B %Y"), new_x="LMARGIN", new_y="NEXT"
+            0,
+            10,
+            datetime.now().strftime(self.date_format),
+            new_x="LMARGIN",
+            new_y="NEXT",
         )
 
         if self.page_no() > 1:
@@ -306,19 +312,21 @@ def export_to_excel(patch_reports: List[Dict], output_dir: AnyStr) -> AnyStr:
 
 
 # Create PDF from Excel file
-def export_excel_to_pdf(excel_file: AnyStr) -> None:
+def export_excel_to_pdf(excel_file: AnyStr, date_format: AnyStr = "%B %d %Y") -> None:
     """
     Creates a PDF report from an Excel file containing patch data.
 
     :param excel_file: Path to the Excel file to convert to PDF.
     :type excel_file: AnyStr
+    :param date_format: The date format string for the PDF report header.
+    :type date_format: AnyStr
     """
     try:
         # Read excel file
         df = pd.read_excel(excel_file)
 
         # Create instance of FPDF
-        pdf = PDF()
+        pdf = PDF(date_format=date_format)
         pdf.table_headers = df.columns
         pdf.column_widths = [75, 40, 40, 40, 40, 40]
         pdf.add_page()


### PR DESCRIPTION
### Fixed
- Partly resolves #7 - Date header in PDF defaults to Month Day Year (`%B %d %Y`) instead of Month Day. Additional date format options are available and can be passed with the `--date-format` or `-d` arguments. See [date formats](https://github.com/liquidz00/Patcher/blob/4663c3d4687f61f85bb3a8a80a5804633bf44a03/patcher.py#L14-L20) in Patcher. 