### PR TITLE
Setup Assistant Refactoring

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows/* @liquidz00 @ball42

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,17 +4,26 @@ about: Suggest an idea for this project
 title: "[FEATURE] Your feature request title"
 labels: enhancement
 assignees: ''
-
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Current Behavior
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+> Briefly describe how the project currently behaves or what limitations exist that prompted this request.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Proposed Change
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+> A description of the feature or improvement you are suggesting. Focus on what you'd like to see happen.
+
+## Additional Context
+
+> Include any screenshots, references, or context that would help others understand your proposal.
+
+## Optional Components
+
+### Sample Code (if applicable)
+
+> If you have any code snippets or mockups that demonstrate the feature, please include them here.
+
+### Related Issues
+
+> If applicable, please link to any existing or previously closed issues related to this request.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/build-release-publish.yml
+++ b/.github/workflows/build-release-publish.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  #v5.6.0
         with:
           python-version: '3.x'
 
@@ -41,25 +41,25 @@ jobs:
         run: python3 -m build
 
       - name: Store distribution package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: patcher-${{ env.VERSION }}
           path: dist/
 
       - name: Publish package to PyPI
         id: publish_pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
 
       - name: Get Changelog updates
         id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2.2.3
+        uses: mindsers/changelog-reader-action@32aa5b4c155d76c94e4ec883a223c947b2f02656  # v2.2.3
         with:
           validation_depth: 100
           version: v${{ env.VERSION }}
 
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v4.3.1
+        uses: metcalfc/changelog-generator@d552ecf3366cf9d6da9fd7dbe425325d3d095aa8  # v4.3.1
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           reverse: 'true'
@@ -67,7 +67,7 @@ jobs:
       - name: Create Release
         id: create_release
         if: ${{ steps.publish_pypi.outcome == 'success' }}
-        uses: softprops/action-gh-release@v2.0.6
+        uses: softprops/action-gh-release@a74c6b72af54cfa997e81df42d94703d6313a2d0  # v2.0.6
         with:
           name: Patcher ${{ env.VERSION }}
           tag_name: v${{ env.VERSION }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  #v5.6.0
         with:
           python-version: '3.x'
 
@@ -43,10 +43,10 @@ jobs:
         run: make docs
 
       - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: 'docs/_build/'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -3,15 +3,17 @@ name: Publish to Test PyPi
 on:
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   build:
     name: Build distro
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  #v5.6.0
         with:
           python-version: "3.x"
       - name: Install pypa/build
@@ -21,7 +23,7 @@ jobs:
       - name: Build binary wheel and source tarbell
         run: python3 -m build
       - name: Store distribution package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: python-package-distributions
           path: dist/
@@ -42,7 +44,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: python-package-distributions
           path: dist/
@@ -50,7 +52,7 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,8 @@ name: Run Tests
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   run-tests:
     strategy:
@@ -16,10 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  #v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/docs/reference/setup.rst
+++ b/docs/reference/setup.rst
@@ -1,13 +1,32 @@
-:html_theme.sidebar_secondary.remove: True
-
 =====
 Setup
 =====
 
-.. autoclass:: patcher.client.setup.SetupType
+Setup State Manager
+-------------------
+
+.. autoclass:: patcher.client.setup.SetupStateManager
     :members:
-    :show-inheritance:
+
+Setup Class
+-----------
 
 .. autoclass:: patcher.client.setup.Setup
     :members:
 
+Module Enums
+------------
+
+Setup Type
+^^^^^^^^^^
+
+.. autoclass:: patcher.client.setup.SetupType
+    :members:
+    :undoc-members:
+
+Setup Stage
+^^^^^^^^^^^
+
+.. autoclass:: patcher.client.setup.SetupStage
+    :members:
+    :undoc-members:

--- a/docs/user/reset.rst
+++ b/docs/user/reset.rst
@@ -7,6 +7,9 @@ Reset
 ======
 
 The ``reset`` command restores specific configurations in Patcher, allowing users to reset **credentials, UI settings, or cached data**. By default, a **full reset** clears all configurations and triggers the setup process. Users can reset individual components without affecting other settings.
+
+.. seealso::
+    For more on resuming or forcing a fresh setup, see :ref:`Resumable Setup <starting_fresh>`. 
  
 Parameters
 ----------

--- a/docs/user/setup_assistant.rst
+++ b/docs/user/setup_assistant.rst
@@ -41,6 +41,52 @@ Once setup is completed successfully, the ``setup_completed`` key will automatic
 
     **Do not modify** the ``setup_completed`` key directly. Altering this key may lead to unexpected behavior. If you need to reset the initial setup state, use the ``--reset`` command instead. For more information, see :ref:`resetting Patcher <resetting_patcher>`.
 
+.. _starting_fresh:
+
+Resumable Setup
+---------------
+
+.. versionadded:: 2.2.0
+
+The setup assistant has been enhanced with **staged progress tracking**. This means that if setup fails or is interrupted (e.g., file issues, API errors, network loss), Patcher will resume where it left off the next time it is run. 
+
+This is accomplished using a hidden JSON file stored at:
+
+.. code-block:: console
+
+    ~/Library/Application Support/Patcher/.setup_stage.json.
+ 
+The file self-destructs (deletes) when setup is marked as completed and automatically managed by Patcher. It stores a stage marker that allows the tool to intelligently resume from the last successful step. 
+
+The stages are: 
+
+- ``not_started``: Initial stage
+- ``api_created``: API Role & Client has been saved to Keychain
+- ``has_token``: Bearer Token has been fetched
+- ``jamfclient_saved``: A :class:`~patcher.models.jamf_client.JamfClient` object has been created and saved to Keychain
+- ``completed``: Setup has been completed as expected. 
+
+.. note::
+
+    This workflow ensures you **don't lose your progress** if setup fails. Simply relaunch the CLI and Patcher will continue setup automatically.
+
+Forcing Setup to Start Over
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are circumstances in which you may want to rerun the setup process *from scratch*, even if some steps were already completed. For example: 
+
+- You want to create a new API Client
+- You entered incorrect credentials and want a clean slate
+- You're testing Patcher out in a development environment
+
+You can do this by passing the ``--fresh`` flag to Patcher: 
+
+.. code-block:: console
+
+    $ patcherctl --fresh
+
+This tells Patcher to **ignore the saved setup stage** and begin from ``not_started`` again. This does not affect any cached data, it only resets the setup flow itself.
+
 .. _setup_type:
 
 Choosing Setup type

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -57,6 +57,8 @@ Patcher leverages specific exit codes depending on what type of error occurred a
         - Handled exception (e.g., PatcherError or user-facing issue)
       * - 2
         - Unhandled exception
+      * - 3
+        - Setup error
       * - 4
         - API error (e.g., unauthorized, invalid response)
       * - 130

--- a/src/patcher/client/setup.py
+++ b/src/patcher/client/setup.py
@@ -1,4 +1,6 @@
+import json
 from enum import Enum
+from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
 
 import asyncclick as click
@@ -26,9 +28,82 @@ You will be prompted to enter in the header and footer text for PDF reports, alo
 DOC = "For more information, visit the project documentation: https://patcher.liquidzoo.io\n"
 
 
-class SetupType(Enum):
+class SetupType(str, Enum):
+    """
+    Defines the method of setup used for configuring Patcher.
+
+    - ``STANDARD``: Prompts for Jamf Pro username/password and creates an API client.
+    - ``SSO``: Prompts for an existing API client ID and secret.
+    """
     STANDARD = "standard"
     SSO = "sso"
+
+
+class SetupStage(str, Enum):
+    """
+    Represents the sequential stages in the setup process.
+
+    Used to track progress and allow resuming setup from the last completed step.
+    """
+    NOT_STARTED = "not_started"
+    API_CREATED = "api_created"
+    HAS_TOKEN = "has_token"
+    JAMFCLIENT_SAVED = "jamfclient_saved"
+    COMPLETED = "completed"
+
+
+class SetupStateManager:
+    def __init__(self, state_path: Path):
+        """
+        Manages reading, writing, and resetting the current setup stage.
+
+        This class is responsible for persisting setup progress to a JSON file,
+        allowing the setup process to be resumed from the last known stage.
+
+        :param state_path: Filesystem path to the JSON file used to persist setup stage.
+        :type state_path: :py:obj:`~pathlib.Path`
+        """
+        self.state_path = state_path
+
+    def load_stage(self) -> SetupStage:
+        """
+        Loads the saved setup stage from disk. If the file does not exist or is invalid,
+        defaults to :attr:`~patcher.client.setup.SetupStage.NOT_STARTED`.
+
+        Creates the stage file if it doesn't already exist.
+
+        :return: The current saved setup stage.
+        :rtype: :class:`~patcher.client.setup.SetupStage`
+        """
+        if not self.state_path.exists():
+            self.state_path.touch()
+            return SetupStage.NOT_STARTED
+        try:
+            with open(self.state_path, "r") as f:
+                data = json.load(f)
+                return SetupStage(data.get("setup_stage", SetupStage.NOT_STARTED))
+        except Exception:  # intentional, using as fail-safe
+            return SetupStage.NOT_STARTED
+
+    def save_stage(self, stage: SetupStage) -> None:
+        """
+        Persists the provided setup stage to disk.
+
+        Creates the parent directory if it does not exist.
+
+        :param stage: The setup stage to persist.
+        :type stage: :class:`~patcher.client.setup.SetupStage`
+        """
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.state_path, "w") as f:
+            json.dump({"setup_stage": stage.value}, f)
+
+    def destroy(self) -> None:
+        """
+        Deletes the persisted setup stage file if it exists.
+        """
+        if self.state_path.exists():
+            self.state_path.unlink()
 
 
 class Setup:
@@ -49,6 +124,8 @@ class Setup:
         :type config: :class:`~patcher.client.config_manager.ConfigManager`
         :param ui_config: Handles UI-related configurations for the setup process.
         :type ui_config: :class:`~patcher.client.ui_manager.UIConfigManager`
+        :param plist_manager: Handles read/write operations to project property list.
+        :type plist_manager: :class:`~patcher.client.plist_manager.PropertyListManager`
         """
         self.config = config
         self.ui_config = ui_config
@@ -56,6 +133,16 @@ class Setup:
         self.log = LogMe(self.__class__.__name__)
         self.animator = Animation()
         self._completed = None
+        self.state_manager = SetupStateManager(
+            Path.home() / "Library/Application Support/Patcher/.setup_stage.json"
+        )
+        self._stage = None
+        self.stage_map = {
+            SetupStage.NOT_STARTED: self.not_started,
+            SetupStage.API_CREATED: self.api_created,
+            SetupStage.HAS_TOKEN: self.has_token,
+            SetupStage.JAMFCLIENT_SAVED: self.jamfclient_saved,
+        }
 
     @property
     def completed(self) -> bool:
@@ -70,20 +157,54 @@ class Setup:
             self._completed = self.plist_manager.get("setup_completed") or False
         return self._completed
 
+    @property
+    def stage(self) -> SetupStage:
+        if self._stage is None:
+            self._stage = self.state_manager.load_stage()
+        return self._stage
+
+    @stage.setter
+    def stage(self, value: SetupStage) -> None:
+        self._stage = value
+
     @staticmethod
-    def _greet():
+    def _greet() -> None:
         """Displays the greeting and welcome messages."""
         click.echo(click.style(GREET, fg="cyan", bold=True))
         click.echo(click.style(WELCOME), nl=False)
         click.echo(click.style(DOC, fg="bright_magenta", bold=True))
 
-    def _mark_completion(self, value: bool = False):
-        """Updates the plist file to reflect the completion status of the setup."""
+    def _mark_completion(self, value: bool = False) -> None:
+        """
+        Updates the plist file to reflect the completion status of the setup.
+        Additionally deletes the setup stage file if ``value`` is ``True``.
+        """
         self.plist_manager.set("setup_completed", value)
         self._completed = value
+        if value:
+            self.state_manager.destroy()
 
-    def _prompt_credentials(self, setup_type: SetupType) -> Optional[Dict]:
-        """Prompt for credentials based on the credential type."""
+    def _get_creds(self, include_token: bool = False) -> Dict:
+        """Retrieves all stored credentials from keychain."""
+        keys = ["URL", "CLIENT_ID", "CLIENT_SECRET"]
+        if include_token:
+            keys.append("TOKEN")
+        return {key: self.config.get_credential(key) for key in keys}
+
+    def _save_creds(self, creds: Dict) -> None:
+        """Save gathered credentials to keychain."""
+        for key, value in creds.items():
+            self.config.set_credential(key, value)
+
+    def prompt_credentials(self, setup_type: SetupType) -> Dict:
+        """
+        Prompt for credentials based on the credential type.
+
+        :param setup_type: The ``SetupType`` of credentials to prompt for.
+        :type setup_type: :class:`~patcher.client.setup.SetupType`
+        :return: The credentials in dictionary form.
+        :rtype: :py:obj:`~typing.Dict`
+        """
         self.log.info(f"Prompting user for {setup_type.value} credentials.")
         if setup_type == SetupType.STANDARD:
             return {
@@ -98,10 +219,20 @@ class Setup:
                 "CLIENT_SECRET": click.prompt("Enter your API Client Secret"),
             }
 
-    def _validate_creds(
+    def validate_creds(
         self, creds: Dict, required_keys: Tuple[str, ...], setup_type: SetupType
     ) -> None:
-        """Validates all required keys are present in the credentials."""
+        """
+        Validates all required keys are present in the credentials.
+
+        :param creds: Credentials to validate
+        :type creds: :py:obj:`~typing.Dict`
+        :param required_keys: Keys required to be present in passed credentials.
+        :type required_keys: :py:obj:`~typing.Tuple` [:py:class:`str`, ...]
+        :param setup_type: The ``SetupType`` to validate credentials against.
+        :type setup_type: :class:`~patcher.client.setup.SetupType`
+        :raises SetupError: If any credentials are missing.
+        """
         self.log.info(f"Validating credentials for {setup_type.value} setup.")
         missing_keys = [key for key in required_keys if not creds.get(key)]
         if missing_keys:
@@ -114,26 +245,38 @@ class Setup:
                 setup_type=setup_type.value,
             )
 
-    def _save_creds(self, creds: Dict) -> None:
-        """Save gathered credentials to keychain."""
-        for key, value in creds.items():
-            self.config.set_credential(key, value)
+    def prompt_installomator(self) -> None:
+        """
+        Prompts user to enable or disable Installomator support.
 
-    def _prompt_installomator(self):
-        """Prompts user to enable or disable Installomator support."""
+        If enabled, assists in identifying :class:`~patcher.models.patch.PatchTitle` objects with Installomator support,
+        used during :ref:`analyze <analyze>` commands.
+        """
         use_installomator = click.confirm(
             "Would you like to enable Installomator support?", default=True
         )
         self.plist_manager.set("enable_installomator", use_installomator)
 
-    async def _token_fetching(
+    async def get_token(
         self, setup_type: SetupType = SetupType.STANDARD, creds: Optional[Dict] = None
-    ) -> Optional[Union[str, AccessToken]]:
-        """Fetches a Token (basic or ``AccessToken``) depending on setup type (Standard or SSO)."""
+    ) -> Union[str, AccessToken]:
+        """
+        Fetches a Token (basic or ``AccessToken``) depending on setup type (Standard or SSO).
+
+        :param setup_type: ``SetupType`` specified dictates which type of Token will be retrieved (basic or bearer).
+        :type setup_type: :class:`~patcher.client.setup.SetupType`
+        :param creds: If ``SetupType`` is "Standard", the user credentials needed to obtain a basic token.
+        :type creds: :py:obj:`~typing.Optional` [:py:obj:`~typing.Dict`]
+        :raises SetupError: If either type of Token could not be obtained.
+        :return: For ``SetupType.STANDARD``, the basic token is returned. For ``SetupType.SSO``, the ``AccessToken`` object is returned.
+        :rtype: :py:obj:`~typing.Union` [:py:class:`str`, :class:`~patcher.models.token.AccessToken`]
+        """
         if setup_type == SetupType.SSO:
             token_manager = TokenManager(self.config)
             try:
-                return await token_manager.fetch_token()
+                token = await token_manager.fetch_token()
+                token_manager.save_token(token)
+                return token
             except TokenError as e:
                 raise SetupError(
                     "Failed to obtain an AccessToken during setup. Please check your credentials and try again.",
@@ -156,10 +299,18 @@ class Setup:
                     error_msg=str(e),
                 )
 
-    async def _configure_integration(
-        self, basic_token: str, jamf_url: str
-    ) -> Optional[Tuple[str, str]]:
-        """Creates API Role and Client for standard setup types."""
+    async def create_api_client(self, basic_token: str, jamf_url: str) -> Tuple[str, str]:
+        """
+        Creates API Role and Client for standard setup types.
+
+        :param basic_token: The basic token used for authorization in creating API Role and Client
+        :type basic_token: :py:class:`str`
+        :param jamf_url: The Jamf Pro instance URL to create API Role and Clients in.
+        :type jamf_url: :py:class:`str`
+        :raises SetupError: If either the API Role or API Client could not be created.
+        :return: The client ID and client secret of the created API Client and Role.
+        :rtype: :py:obj:`~typing.Tuple` [:py:class:`str`, :py:class:`str`]
+        """
         api_client = BaseAPIClient()
         if not await api_client.create_roles(token=basic_token, jamf_url=jamf_url):
             self.log.error(
@@ -178,98 +329,97 @@ class Setup:
                     "Failed to create Patcher API Client as expected.", error_msg=str(e)
                 )
 
-    async def _run_setup(self, setup_type: SetupType, animator: Optional[Animation] = None) -> None:
-        """Handles both types of setup for end-users based on passed `setup_type`."""
-        if self.completed:
-            return
+    async def not_started(self, animator: Animation, setup_type: SetupType) -> None:
+        """
+        Handles the initial setup stage based on the selected setup type.
 
-        # Setup animation
-        animator = animator or self.animator
+        For ``STANDARD`` setup, prompts the user for username/password, creates a new API client,
+        and saves credentials. For ``SSO``, stores the provided client credentials.
 
-        # Prompt for credentials
-        creds = self._prompt_credentials(setup_type)
-
-        # Prompt for installomator
-        self._prompt_installomator()
-
+        :param animator: The animation instance to update messages.
+        :type animator: :class:`~patcher.utils.animation.Animation`
+        :param setup_type: The selected setup type (Standard or SSO).
+        :type setup_type: :class:`~patcher.client.setup.SetupType`
+        :raises SetupError: If credentials are missing or a token cannot be obtained.
+        """
+        creds = self.prompt_credentials(setup_type)
+        self.prompt_installomator()
         if setup_type == SetupType.STANDARD:
-            # `launch` method
-            self.log.debug(
-                "Detected first run has not been completed. Starting standard (non-SSO) Setup..."
-            )
-
-            # Validate needed credentials are present
-            await animator.update_msg("Starting Standard setup...")
-            self._validate_creds(creds, ("USERNAME", "PASSWORD", "URL"), setup_type)
-
-            # Extract jamf_url
-            jamf_url = creds.get("URL")
-
-            # Retrieve basic token
+            self.validate_creds(creds, ("USERNAME", "PASSWORD", "URL"), SetupType.STANDARD)
             await animator.update_msg("Retrieving basic token")
-            basic_token = await self._token_fetching(setup_type=SetupType.STANDARD, creds=creds)
-
-            # Create API Role and Client
+            basic_token = await self.get_token(setup_type=setup_type, creds=creds)
             await animator.update_msg("Creating API integrations")
-            client_id, client_secret = await self._configure_integration(
-                basic_token=basic_token, jamf_url=jamf_url
+            client_id, client_secret = await self.create_api_client(basic_token, creds.get("URL"))
+            self._save_creds(
+                {"URL": creds.get("URL"), "CLIENT_ID": client_id, "CLIENT_SECRET": client_secret}
             )
-
-            # Save credentials
-            client_creds = {"URL": jamf_url, "CLIENT_ID": client_id, "CLIENT_SECRET": client_secret}
-            self._save_creds(client_creds)
-
-            # Retrieve AccessToken
-            await animator.update_msg("Fetching AccessToken")
-            token = await self._token_fetching(setup_type=SetupType.SSO, creds=client_creds)
-
-            # Setup JamfClient
-            await animator.update_msg("Creating JamfClient...")
-            self.config.create_client(
-                JamfClient(
-                    client_id=client_id,
-                    client_secret=client_secret,
-                    server=jamf_url,
-                ),
-                token=token,
-            )
+            self.state_manager.save_stage(SetupStage.API_CREATED)
+            self.stage = SetupStage.API_CREATED
         elif setup_type == SetupType.SSO:
-            # `first_run` method
-            self.log.debug("Detected first run has not been completed. Starting SSO setup...")
-
-            # Ensure client ID and client secret are present in credentials
-            await animator.update_msg("Starting SSO setup...")
-            self._validate_creds(creds, ("CLIENT_ID", "CLIENT_SECRET", "URL"), setup_type)
-
-            # Store credentials
+            self.validate_creds(creds, ("CLIENT_ID", "CLIENT_SECRET", "URL"), SetupType.SSO)
             await animator.update_msg("Saving credentials...")
             self._save_creds(creds)
+            self.state_manager.save_stage(SetupStage.API_CREATED)
+            self.stage = SetupStage.API_CREATED
 
-            # Fetch token
-            await animator.update_msg("Fetching AccessToken...")
-            token = await self._token_fetching(setup_type=SetupType.SSO, creds=creds)
+    async def api_created(self, animator: Animation, _setup_type: SetupType) -> None:
+        """
+        Handles the stage after API credentials have been created or provided.
 
-            # Setup JamfClient
-            await animator.update_msg("Creating JamfClient...")
-            self.config.create_client(
-                JamfClient(
-                    client_id=creds.get("CLIENT_ID"),
-                    client_secret=creds.get("CLIENT_SECRET"),
-                    server=creds.get("URL"),
-                ),
-                token=token,
-            )
+        Attempts to fetch and persist an ``AccessToken`` using stored credentials.
 
-        # Set stop event before prompting
+        :param animator: The animation instance to update messages.
+        :type animator: :class:`~patcher.utils.animation.Animation`
+        :param _setup_type: Placeholder to satisfy stage dispatch signature. Not used in this stage.
+        :type _setup_type: :class:`~patcher.client.setup.SetupType`
+        :raises SetupError: If an :class:`~patcher.models.token.AccessToken` cannot be retrieved
+        """
+        await animator.update_msg("Fetching AccessToken")
+        client_creds = self._get_creds()
+        await self.get_token(setup_type=SetupType.SSO, creds=client_creds)
+        self.state_manager.save_stage(SetupStage.HAS_TOKEN)
+        self.stage = SetupStage.HAS_TOKEN
+
+    async def has_token(self, animator: Animation, _setup_type: SetupType) -> None:
+        """
+        Handles the stage after a token has been obtained.
+
+        Uses stored credentials and token to instantiate and store a ``JamfClient`` object.
+
+        :param animator: The animation instance to update messages.
+        :type animator: :class:`~patcher.utils.animation.Animation`
+        :param _setup_type: Placeholder to satisfy stage dispatch signature. Not used in this stage.
+        :type _setup_type: :class:`~patcher.client.setup.SetupType`
+        """
+        await animator.update_msg("Creating JamfClient...")
+        client_creds = self._get_creds(include_token=True)
+        self.config.create_client(
+            JamfClient(
+                client_id=client_creds.get("CLIENT_ID"),
+                client_secret=client_creds.get("CLIENT_SECRET"),
+                server=client_creds.get("URL"),
+            ),
+            token=client_creds.get("TOKEN"),
+        )
+        self.state_manager.save_stage(SetupStage.JAMFCLIENT_SAVED)
+        self.stage = SetupStage.JAMFCLIENT_SAVED
+
+    async def jamfclient_saved(self, animator: Animation, _setup_type: SetupType) -> None:
+        """
+        Final stage in setup: configures user interface settings and marks setup as complete.
+
+        :param animator: The animation instance to update messages.
+        :type animator: :class:`~patcher.utils.animation.Animation`
+        :param _setup_type: Placeholder to satisfy stage dispatch signature. Not used in this stage.
+        :type _setup_type: :class:`~patcher.client.setup.SetupType`
+        """
         await animator.stop()
-
-        # Setup UI components
         self.ui_config.setup_ui()
-
-        # Mark setup as complete
+        self.state_manager.save_stage(SetupStage.COMPLETED)
+        self.stage = SetupStage.COMPLETED
         self._mark_completion(value=True)
 
-    async def start(self, animator: Optional[Animation] = None) -> None:
+    async def start(self, animator: Optional[Animation] = None, fresh: bool = False) -> None:
         """
         Allows the user to choose between different setup methods (Standard or SSO).
 
@@ -286,6 +436,8 @@ class Setup:
 
         :param animator: The animation instance to update messages. Defaults to ``self.animator``.
         :type animator: :py:obj:`~typing.Optional` [:class:`~patcher.utils.animation.Animation`]
+        :param fresh: If ``True``, starts setup from scratch regardless of previous stage saved.
+        :type fresh: :py:class:`bool`
         :raises SetupError: If a token could not be fetched, credentials are missing or setup could not be marked complete.
         """
         if self.completed:
@@ -301,7 +453,14 @@ class Setup:
             "Choose setup method (1: Standard setup, 2: SSO setup)", type=int, default=1
         )
         if choice in setup_type_map:
-            await self._run_setup(setup_type_map[choice], animator=animator)
+            if fresh:
+                self.stage = SetupStage.NOT_STARTED
+
+            while self.stage != SetupStage.COMPLETED:
+                handler = self.stage_map.get(self.stage)
+                if handler is None:
+                    raise SetupError("Missing handler for saved stage", stage=self.stage)
+                await handler(animator, setup_type_map[choice])
         else:
             click.echo(click.style("Invalid choice, please choose 1 or 2", fg="red"))
             await self.start()

--- a/src/patcher/client/setup.py
+++ b/src/patcher/client/setup.py
@@ -161,12 +161,24 @@ class Setup:
 
     @property
     def stage(self) -> SetupStage:
+        """
+        Returns the current ``SetupStage`` value used to determine setup state.
+
+        :return: The ``SetupStage`` value. 
+        :rtype: :class:`~patcher.client.setup.SetupStage`
+        """
         if self._stage is None:
             self._stage = self.state_manager.load_stage()
         return self._stage
 
     @stage.setter
     def stage(self, value: SetupStage) -> None:
+        """
+        Assigns a ``SetupStage`` value to the stage property.
+
+        :param value: The value to assign to ``self.stage``. 
+        :type value: :class:`~patcher.client.setup.SetupStage`
+        """
         self._stage = value
 
     @staticmethod

--- a/src/patcher/client/setup.py
+++ b/src/patcher/client/setup.py
@@ -35,6 +35,7 @@ class SetupType(str, Enum):
     - ``STANDARD``: Prompts for Jamf Pro username/password and creates an API client.
     - ``SSO``: Prompts for an existing API client ID and secret.
     """
+
     STANDARD = "standard"
     SSO = "sso"
 
@@ -45,6 +46,7 @@ class SetupStage(str, Enum):
 
     Used to track progress and allow resuming setup from the last completed step.
     """
+
     NOT_STARTED = "not_started"
     API_CREATED = "api_created"
     HAS_TOKEN = "has_token"

--- a/src/patcher/client/setup.py
+++ b/src/patcher/client/setup.py
@@ -164,7 +164,7 @@ class Setup:
         """
         Returns the current ``SetupStage`` value used to determine setup state.
 
-        :return: The ``SetupStage`` value. 
+        :return: The ``SetupStage`` value.
         :rtype: :class:`~patcher.client.setup.SetupStage`
         """
         if self._stage is None:
@@ -176,7 +176,7 @@ class Setup:
         """
         Assigns a ``SetupStage`` value to the stage property.
 
-        :param value: The value to assign to ``self.stage``. 
+        :param value: The value to assign to ``self.stage``.
         :type value: :class:`~patcher.client.setup.SetupStage`
         """
         self._stage = value

--- a/src/patcher/client/token_manager.py
+++ b/src/patcher/client/token_manager.py
@@ -150,11 +150,11 @@ class TokenManager:
         expiration = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
         access_token = AccessToken(token=token, expires=expiration)
 
-        self._save_token(token=access_token)
+        self.save_token(token=access_token)
         self.log.info("New token fetched and saved successfully")
         return access_token
 
-    def _save_token(self, token: AccessToken):
+    def save_token(self, token: AccessToken):
         """
         This method stores the access token and its expiration date in the keyring
         for later retrieval. It also updates the ``JamfClient`` instance with the new token.

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -19,7 +19,7 @@ def test_token_manager_initialization(mock_token, config_manager):
 
 
 @patch.object(ConfigManager, "set_credential", new_callable=MagicMock)
-def test_save_token(mock_set_credential):
+def testsave_token(mock_set_credential):
     mock_config_manager = MagicMock()
 
     mock_config_manager.set_credential = mock_set_credential
@@ -27,7 +27,7 @@ def test_save_token(mock_set_credential):
     token_manager = TokenManager(config=mock_config_manager)
     token = AccessToken(token="new_token", expires=datetime(2031, 1, 1, tzinfo=timezone.utc))
 
-    token_manager._save_token(token)
+    token_manager.save_token(token)
 
     expected_calls = [
         call("TOKEN", "new_token"),


### PR DESCRIPTION
## Overview 
Addresses #29 - Setup Assistant progresses through the following stages: 
- `not_started`: The initial setup stage. 
- `api_created`: When an API Role & Client have been created in specified Jamf Pro instance. 
- `has_token`: A bearer token has been retrieved with API credentials.
- `jamfclient_saved`: When a `JamfClient` object has been instantiated and all saved to keychain. 

If an error is thrown during setup, the setup assistant will resume from the last saved stage instead of starting from square one. In the event starting from scratch is ideal, end-users can pass the `--fresh` flag to patcher to force setup to begin at `not_started`. 