### PR TITLE
Non-interactive Setup

### DIFF
--- a/docs/user/ci_cd.md
+++ b/docs/user/ci_cd.md
@@ -1,0 +1,140 @@
+(ci-cd)=
+
+# CI/CD & Non-Interactive Mode
+
+Patcher can run without prompts in environments where the macOS keychain isn't
+available and where persistent state isn't desired — typically GitHub Actions
+runners, Linux build agents, and other ephemeral CI/CD contexts.
+
+## How non-interactive mode works
+
+When all three of the following are provided — via CLI flags **or** environment
+variables — Patcher engages non-interactive mode:
+
+| CLI flag | Environment variable | Description |
+|---|---|---|
+| `--client-id` | `PATCHER_CLIENT_ID` | Jamf Pro API client ID |
+| `--client-secret` | `PATCHER_CLIENT_SECRET` | Jamf Pro API client secret |
+| `--url` | `PATCHER_URL` | Jamf Pro instance URL |
+
+CLI flags take precedence over environment variables. Mix-and-match is fine
+(e.g. URL via env var, secrets via flag).
+
+In non-interactive mode, Patcher:
+
+- **Holds credentials in memory only** for the lifetime of the invocation.
+  The macOS keychain is never read or written.
+- **Skips every interactive prompt** — setup type, Installomator support, and
+  the UI configuration (PDF header/footer/logo) are all bypassed.
+- **Does not persist setup completion** to disk. The next invocation must
+  provide credentials again, which is the desired behavior on ephemeral runners.
+- **Runs the requested subcommand immediately** after fetching an access token.
+
+## Quick example
+
+```bash
+# All three credentials via flags
+patcherctl \
+  --client-id="abc-123" \
+  --client-secret="my-secret" \
+  --url="https://my.jamfcloud.com" \
+  export --path=/tmp/reports --format=json
+
+# Or via environment variables
+export PATCHER_CLIENT_ID=abc-123
+export PATCHER_CLIENT_SECRET=my-secret
+export PATCHER_URL=https://my.jamfcloud.com
+patcherctl export --path=/tmp/reports --format=json
+```
+
+## GitHub Actions example
+
+A complete workflow that runs Patcher daily and uploads the JSON report as a
+build artifact. Adjust the schedule, output path, and artifact retention to
+suit your needs.
+
+```yaml
+name: Patch Report
+
+on:
+  schedule:
+    - cron: '0 13 * * 1-5'  # Weekdays at 13:00 UTC
+  workflow_dispatch:
+
+jobs:
+  generate-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Patcher
+        run: pip install patcherctl
+
+      - name: Generate patch report
+        env:
+          PATCHER_CLIENT_ID: ${{ secrets.JAMF_CLIENT_ID }}
+          PATCHER_CLIENT_SECRET: ${{ secrets.JAMF_CLIENT_SECRET }}
+          PATCHER_URL: ${{ secrets.JAMF_URL }}
+        run: |
+          mkdir -p ./reports
+          patcherctl export --path=./reports --format=json
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: patch-report
+          path: ./reports/*.json
+          retention-days: 30
+```
+
+The JSON output is well-suited to downstream automation — feed it into another
+job that posts to Slack, ingests into a dashboard, or triggers patching policies
+based on coverage thresholds.
+
+## Security considerations
+
+- **Never commit credentials to your repository.** Use GitHub Secrets (or the
+  equivalent on your CI platform) for `JAMF_CLIENT_ID`, `JAMF_CLIENT_SECRET`,
+  and `JAMF_URL`.
+- **Use a dedicated API client.** Create a separate Jamf Pro API client/role
+  for CI/CD with the minimum privileges Patcher needs. See
+  {ref}`Creating an API Role/Client <api-creation>` for details.
+- **Rotate credentials periodically.** Treat the client secret like any other
+  long-lived credential.
+
+## Recommended output formats
+
+For machine-consumable pipelines, JSON is the preferred format:
+
+```bash
+patcherctl export --path=./reports --format=json
+```
+
+The JSON output is structured around a `PatchTitle` schema and includes a
+`generated_at` timestamp, the report title, the title count, and the full list
+of titles with completion percentages. See {ref}`Export <export>` for the
+full format reference.
+
+If you need both JSON (for automation) and PDF (for humans), pass `--format`
+multiple times:
+
+```bash
+patcherctl export --path=./reports --format=json --format=pdf
+```
+
+## What's not supported in non-interactive mode
+
+- **Resetting credentials** (`patcherctl reset creds`) — designed for keychain
+  workflows. In CI you simply update the secrets and re-run.
+- **`--fresh` setup flag** — non-interactive mode skips the setup state machine
+  entirely; this flag has no effect.
+- **UI configuration prompts** — PDF header/footer text and custom logos use
+  built-in defaults. If you need a customized PDF, configure UI settings on a
+  workstation first and commit the resulting plist values, or generate JSON in
+  CI and produce styled PDFs downstream.

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -9,9 +9,9 @@ The User Guide is designed to be your go-to resource for learning how to set up,
 ## What You'll Find Here
 
 - **Getting Started**: Learn about prerequisites, installation, and running the setup assistant to configure Patcher for the first time.
-- **Setup**: Detailed instructions for configuring Patcher to fit your organization's needs, including Jamf Pro integration and scheduling automated reports. 
+- **Setup**: Detailed instructions for configuring Patcher to fit your organization's needs, including Jamf Pro integration and scheduling automated reports.
 - **Usage**: Explore how to use Patcher's commands and features, from exporting patch data and customizing reports to analyzing software titles and trends.
-- **Support and Troubleshooting**: Get answers to common questions and find solutions to potential issues. 
+- **Support and Troubleshooting**: Get answers to common questions and find solutions to potential issues.
 
 * * *
 
@@ -25,7 +25,7 @@ The User Guide is designed to be your go-to resource for learning how to set up,
 :class-title: patcher-title
 :shadow: md
 
-Learn about prerequisites and installation. 
+Learn about prerequisites and installation.
 ```{toctree}
 :caption: Getting Started
 :maxdepth: 2
@@ -61,6 +61,7 @@ setup_assistant
 jamf_deployment
 plist
 schedulereports
+ci_cd
 ```
 
 +++

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,14 @@ select = [
   "N802",
   "N806"
 ]
-per-file-ignores = {"utils/animation.py" = ["F403"]}
 ignore = ["E722"]
+
+[tool.ruff.lint.per-file-ignores]
+"utils/animation.py" = ["F403"]
+# Test code commonly assigns mocks to PascalCase names that stand in for the
+# class being patched (e.g. MockTokenManager = MagicMock()). N806 (non-lowercase
+# variable in function) is the wrong lint to enforce in that context.
+"tests/**/*.py" = ["N806"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"

--- a/src/patcher/cli.py
+++ b/src/patcher/cli.py
@@ -112,8 +112,39 @@ warnings.formatwarning = warning_format
 @click.option(
     "--fresh", is_flag=True, help="Start setup from scratch, ingoring previously saved progress."
 )
+@click.option(
+    "--client-id",
+    envvar="PATCHER_CLIENT_ID",
+    metavar="<client_id>",
+    help=(
+        "Jamf Pro API client ID. When passed alongside --client-secret and --url "
+        "(or via PATCHER_CLIENT_ID, PATCHER_CLIENT_SECRET, PATCHER_URL env vars), "
+        "Patcher runs in non-interactive mode without keychain access — intended "
+        "for CI/CD environments."
+    ),
+)
+@click.option(
+    "--client-secret",
+    envvar="PATCHER_CLIENT_SECRET",
+    metavar="<client_secret>",
+    help="Jamf Pro API client secret. See --client-id for non-interactive mode notes.",
+)
+@click.option(
+    "--url",
+    envvar="PATCHER_URL",
+    metavar="<jamf_url>",
+    help="Jamf Pro instance URL. See --client-id for non-interactive mode notes.",
+)
 @click.pass_context
-async def cli(ctx: click.Context, debug: bool, disable_cache: bool, fresh: bool) -> None:
+async def cli(
+    ctx: click.Context,
+    debug: bool,
+    disable_cache: bool,
+    fresh: bool,
+    client_id: str | None,
+    client_secret: str | None,
+    url: str | None,
+) -> None:
     """
     Main CLI entry point for Patcher.
 
@@ -137,6 +168,12 @@ async def cli(ctx: click.Context, debug: bool, disable_cache: bool, fresh: bool)
     :type disable_cache: bool
     :param fresh: If ``True``, forces the setup assistant to start from scratch. Defaults to ``False``.
     :type fresh: bool
+    :param client_id: Jamf Pro API client ID for non-interactive mode.
+    :type client_id: str | None
+    :param client_secret: Jamf Pro API client secret for non-interactive mode.
+    :type client_secret: str | None
+    :param url: Jamf Pro instance URL for non-interactive mode.
+    :type url: str | None
     """
     setup_logging(debug)
 
@@ -144,14 +181,22 @@ async def cli(ctx: click.Context, debug: bool, disable_cache: bool, fresh: bool)
         cache_dir = Path.home() / "Library/Caches/Patcher"
         initialize_cache(cache_dir)
 
+    # Non-interactive mode is engaged when all three credentials are present
+    # (via flags or PATCHER_* env vars). In that mode we bypass the keychain
+    # and skip every interactive prompt.
+    noninteractive = bool(client_id and client_secret and url)
+
+    config_manager = ConfigManager(in_memory_credentials={}) if noninteractive else ConfigManager()
+
     # Instantiate classes, store in context
     ctx.obj = {
         "debug": debug,
         "disable_cache": disable_cache,
+        "noninteractive": noninteractive,
         "animation": Animation(enable_animation=not debug),
         "log": LogMe(__name__),
         "plist_manager": PropertylistManager(),
-        "config": ConfigManager(),
+        "config": config_manager,
         "ui_config": UIConfigManager(),
     }
 
@@ -160,9 +205,15 @@ async def cli(ctx: click.Context, debug: bool, disable_cache: bool, fresh: bool)
 
     # Check Setup completion
     async with ctx.obj.get("animation").error_handling():
-        if ctx.obj.get("plist_manager").needs_migration():
+        if not noninteractive and ctx.obj.get("plist_manager").needs_migration():
             ctx.obj.get("plist_manager").migrate_plist()
-        if not setup.completed:
+
+        if noninteractive:
+            await setup.bootstrap_noninteractive(
+                client_id=client_id, client_secret=client_secret, url=url
+            )
+            # Fall through — let the requested subcommand run.
+        elif not setup.completed:
             await setup.start(animator=ctx.obj.get("animation"), fresh=fresh)
             click.echo(click.style(text="Setup has completed successfully!", fg="green", bold=True))
             click.echo(

--- a/src/patcher/cli.py
+++ b/src/patcher/cli.py
@@ -310,7 +310,7 @@ async def reset(ctx: click.Context, kind: str, credential: str | None) -> None:
     "formats",
     multiple=True,
     metavar="<format>",
-    type=click.Choice(["excel", "html", "pdf"], case_sensitive=False),
+    type=click.Choice(["excel", "html", "pdf", "json"], case_sensitive=False),
     help="Specify report formats (default: all). Use multiple times for multiple formats.",
 )
 @click.option(
@@ -407,7 +407,7 @@ async def export(
         debug=ctx.obj.get("debug"),
     )
 
-    selected_formats = set(formats) if formats else {"excel", "html", "pdf"}
+    selected_formats = set(formats) if formats else {"excel", "html", "pdf", "json"}
     actual_format = DATE_FORMATS[date_format]
 
     ui_config, plist_manager = ctx.obj.get("ui_config"), ctx.obj.get("plist_manager")

--- a/src/patcher/client/config_manager.py
+++ b/src/patcher/client/config_manager.py
@@ -8,7 +8,11 @@ from ..utils.logger import LogMe
 
 
 class ConfigManager:
-    def __init__(self, service_name: str = "Patcher"):
+    def __init__(
+        self,
+        service_name: str = "Patcher",
+        in_memory_credentials: dict[str, str] | None = None,
+    ):
         """
         Manages configuration settings, primarily focused on handling credentials stored in the macOS keychain.
 
@@ -18,17 +22,35 @@ class ConfigManager:
         ``ConfigManager`` objects are initialized with a default service name of "Patcher", which is used as a
         namespace for storing and retrieving credentials in macOS keychain.
 
+        For non-interactive use (CI/CD environments without a keychain backend), pass
+        ``in_memory_credentials`` to bypass the keychain entirely. Reads check the
+        in-memory dict first and fall through to keyring only if the key is absent.
+        Writes go to the in-memory dict only — keyring is not touched.
+
         :param service_name: Service name for storing credentials in the keyring. Defaults to 'Patcher'.
         :type service_name: str
+        :param in_memory_credentials: Optional dict of credentials held in memory; when present
+            the keyring is not used for either reads or writes.
+        :type in_memory_credentials: dict[str, str] | None
         """
         self.log = LogMe(self.__class__.__name__)
         self.service_name = service_name
-        self.log.debug(f"ConfigManager initialized with service name: {self.service_name}")
+        self._memory: dict[str, str] | None = (
+            dict(in_memory_credentials) if in_memory_credentials is not None else None
+        )
+        mode = "in-memory" if self._memory is not None else "keyring"
+        self.log.debug(f"ConfigManager initialized with service name: {self.service_name} ({mode})")
+
+    @property
+    def in_memory_mode(self) -> bool:
+        """Whether this manager bypasses the keyring (CI/CD-friendly mode)."""
+        return self._memory is not None
 
     def get_credential(self, key: str) -> str:
         """
-        This method is useful for accessing stored credentials without hardcoding them in scripts.
-        It ensures that sensitive data like passwords or API tokens are securely stored and retrieved.
+        Retrieves a credential by key. In in-memory mode, returns from the
+        in-memory dict (or ``None`` if absent). Otherwise reads from the
+        macOS keychain.
 
         :param key: The key of the credential to retrieve, typically a descriptive name like 'API_KEY'.
         :type key: str
@@ -37,6 +59,15 @@ class ConfigManager:
         :raises CredentialError: If the specified credential could not be retrieved.
         """
         self.log.debug(f"Attempting to retrieve credential for key: '{key}'")
+
+        if self.in_memory_mode:
+            credential = self._memory.get(key)
+            if credential:
+                self.log.info(f"Credential for key '{key}' retrieved from in-memory store.")
+            else:
+                self.log.warning(f"Credential for key '{key}' not present in in-memory store.")
+            return credential
+
         try:
             credential = keyring.get_password(self.service_name, key)
             if credential:
@@ -53,10 +84,9 @@ class ConfigManager:
 
     def set_credential(self, key: str, value: str) -> None:
         """
-        Stores a credential in the keyring under the specified key.
-
-        Method is used to securely store sensitive data such as Jamf URL, API Tokens, and API credentials
-        such as client ID and client secret.
+        Stores a credential. In in-memory mode, writes to the in-memory dict
+        only — the keychain is never touched. Otherwise writes to the macOS
+        keychain.
 
         :param key: The key under which the credential will be stored. This acts as an identifier for the credential.
         :type key: str
@@ -65,6 +95,12 @@ class ConfigManager:
         :raises CredentialError: If the specified credential could not be saved.
         """
         self.log.debug(f"Attempting to store credential for key: '{key}'")
+
+        if self.in_memory_mode:
+            self._memory[key] = value
+            self.log.info(f"Credential for key '{key}' stored in in-memory store.")
+            return
+
         try:
             keyring.set_password(self.service_name, key, value)
             self.log.info(f"Credential for key '{key}' set successfully")

--- a/src/patcher/client/setup.py
+++ b/src/patcher/client/setup.py
@@ -435,6 +435,53 @@ class Setup:
         self.stage = SetupStage.COMPLETED
         self._mark_completion(value=True)
 
+    async def bootstrap_noninteractive(
+        self,
+        client_id: str,
+        client_secret: str,
+        url: str,
+    ) -> None:
+        """
+        Non-interactive setup path for CI/CD environments.
+
+        Skips all prompts (setup type, Installomator, UI configuration). The provided
+        credentials are stored via the configured :class:`ConfigManager` — when that
+        manager is in in-memory mode (the typical CI/CD setup) the macOS keychain is
+        not touched. An access token is then fetched so subsequent API calls succeed.
+
+        Setup completion is marked in memory only — no plist mutation. The next
+        invocation will need to provide credentials again, which is the desired
+        behavior on ephemeral runners.
+
+        :param client_id: Jamf Pro API client ID.
+        :type client_id: str
+        :param client_secret: Jamf Pro API client secret.
+        :type client_secret: str
+        :param url: Jamf Pro instance URL.
+        :type url: str
+        :raises SetupError: If a token cannot be obtained with the provided credentials.
+        """
+        self.log.info("Bootstrapping Patcher in non-interactive mode.")
+
+        self.config.set_credential("URL", url)
+        self.config.set_credential("CLIENT_ID", client_id)
+        self.config.set_credential("CLIENT_SECRET", client_secret)
+
+        token_manager = TokenManager(self.config)
+        try:
+            await token_manager.fetch_token()
+        except TokenError as e:
+            self.log.error(f"Non-interactive token fetch failed. Details: {e}")
+            raise SetupError(
+                "Failed to obtain an AccessToken in non-interactive mode. "
+                "Verify the provided credentials are correct.",
+                error_msg=str(e),
+            )
+
+        # Mark completion in memory only — do not write to plist.
+        self._completed = True
+        self.log.info("Non-interactive bootstrap completed successfully.")
+
     async def start(self, animator: Animation | None = None, fresh: bool = False) -> None:
         """
         Allows the user to choose between different setup methods (Standard or SSO).

--- a/src/patcher/utils/data_manager.py
+++ b/src/patcher/utils/data_manager.py
@@ -1,7 +1,8 @@
 import asyncio
+import json
 import pickle
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from string import Template
 
@@ -14,6 +15,35 @@ from ..models.patch import PatchDevice, PatchTitle
 from .exceptions import PatcherError
 from .logger import LogMe
 from .pdf_report import PDFReport
+
+
+def serialize_titles_to_dict(
+    patch_titles: list[PatchTitle], report_title: str | None = None
+) -> dict:
+    """Convert a list of :class:`PatchTitle` into a JSON-serializable dict.
+
+    Pure function with no I/O — safe to call from CLI export, library code,
+    or anywhere a structured representation of the titles is useful.
+
+    The returned dict has the shape::
+
+        {
+            "generated_at": "2026-05-04T18:30:00+00:00",
+            "report_title": "...",
+            "title_count": 42,
+            "titles": [<PatchTitle.model_dump()>, ...]
+        }
+
+    :param patch_titles: List of :class:`PatchTitle` objects to serialize.
+    :param report_title: Optional title carried through to consumers.
+    :return: A dict ready for ``json.dump`` or direct programmatic use.
+    """
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "report_title": report_title,
+        "title_count": len(patch_titles),
+        "titles": [title.model_dump(mode="json") for title in patch_titles],
+    }
 
 
 class DataManager:
@@ -192,6 +222,16 @@ class DataManager:
 
         export_dir.mkdir(parents=True, exist_ok=True)
         return export_dir / filename
+
+    async def _export_json(
+        self,
+        patch_titles: list[PatchTitle],
+        json_path: Path,
+        report_title: str | None,
+    ) -> None:
+        """Writes the serialized titles to ``json_path``."""
+        payload = serialize_titles_to_dict(patch_titles, report_title=report_title)
+        await asyncio.to_thread(json_path.write_text, json.dumps(payload, indent=2))
 
     async def _export_pdf(self, df: pd.DataFrame, pdf_path: Path, date_format: str):
         """Generates a PDF Report from a given DataFrame."""
@@ -445,7 +485,7 @@ class DataManager:
         :rtype: dict[str, str]
         """
         if formats is None:
-            formats = {"excel", "html", "pdf"}
+            formats = {"excel", "html", "pdf", "json"}
 
         exported_files = {}
 
@@ -497,6 +537,20 @@ class DataManager:
         except (OSError, PermissionError) as e:
             raise PatcherError(
                 "Encountered an error saving HTML report.",
+                file_path=str(output_dir),
+                error_msg=str(e),
+            )
+
+        try:
+            # JSON — serialized straight from PatchTitle models (no DataFrame round-trip)
+            # so consumers get the same shape the library exposes programmatically.
+            if "json" in formats:
+                json_path = self._generate_filename(output_dir, "json", analysis)
+                await self._export_json(patch_titles, json_path, report_title)
+                exported_files["json"] = str(json_path)
+        except (OSError, PermissionError) as e:
+            raise PatcherError(
+                "Encountered an error saving JSON report.",
                 file_path=str(output_dir),
                 error_msg=str(e),
             )

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -85,3 +85,52 @@ def test_reset_config_partial_failure(real_config_manager):
         result = real_config_manager.reset_config()
         assert mock_delete_credential.call_count == 5
         assert result is False
+
+
+# In-memory mode (non-interactive / CI/CD)
+
+
+def test_in_memory_mode_property():
+    """A ConfigManager constructed with in_memory_credentials reports in_memory_mode=True."""
+    cm_keychain = ConfigManager(service_name="TestService")
+    cm_memory = ConfigManager(service_name="TestService", in_memory_credentials={})
+
+    assert cm_keychain.in_memory_mode is False
+    assert cm_memory.in_memory_mode is True
+
+
+def test_in_memory_get_returns_from_dict_without_keyring():
+    """get_credential reads from the in-memory dict and never touches keyring."""
+    cm = ConfigManager(
+        service_name="TestService",
+        in_memory_credentials={"CLIENT_ID": "abc-123"},
+    )
+    with patch("keyring.get_password") as mock_keyring:
+        result = cm.get_credential("CLIENT_ID")
+    assert result == "abc-123"
+    mock_keyring.assert_not_called()
+
+
+def test_in_memory_get_returns_none_for_missing_key():
+    """get_credential returns None for absent keys without raising."""
+    cm = ConfigManager(service_name="TestService", in_memory_credentials={})
+    with patch("keyring.get_password") as mock_keyring:
+        assert cm.get_credential("NEVER_SET") is None
+    mock_keyring.assert_not_called()
+
+
+def test_in_memory_set_writes_to_dict_without_keyring():
+    """set_credential writes to the in-memory dict and never touches keyring."""
+    cm = ConfigManager(service_name="TestService", in_memory_credentials={})
+    with patch("keyring.set_password") as mock_keyring:
+        cm.set_credential("CLIENT_SECRET", "shh")
+    assert cm.get_credential("CLIENT_SECRET") == "shh"
+    mock_keyring.assert_not_called()
+
+
+def test_in_memory_constructor_copies_input_dict():
+    """Mutating the dict passed in shouldn't leak into the ConfigManager."""
+    creds = {"URL": "https://example.com"}
+    cm = ConfigManager(service_name="TestService", in_memory_credentials=creds)
+    creds["URL"] = "https://changed.example.com"
+    assert cm.get_credential("URL") == "https://example.com"

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pickle
 from datetime import datetime, timedelta
@@ -8,7 +9,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 from src.patcher.models.patch import PatchTitle
-from src.patcher.utils.data_manager import DataManager
+from src.patcher.utils.data_manager import DataManager, serialize_titles_to_dict
 from src.patcher.utils.exceptions import PatcherError
 
 
@@ -222,3 +223,78 @@ async def test_load_cached_data_with_corrupted_files(mock_data_manager):
 
     # Assert that no valid data was loaded
     assert len(loaded_data) == 0
+
+
+# JSON export tests
+
+
+def test_serialize_titles_to_dict_shape(sample_patch_reports):
+    """The serializer wraps titles in metadata and preserves model fields."""
+    payload = serialize_titles_to_dict(sample_patch_reports, report_title="Test Report")
+
+    assert payload["report_title"] == "Test Report"
+    assert payload["title_count"] == 1
+    assert "generated_at" in payload  # ISO timestamp
+    assert isinstance(payload["titles"], list)
+
+    title = payload["titles"][0]
+    assert title["title"] == "Example Software"
+    assert title["title_id"] == "0"
+    assert title["completion_percent"] == 83.33
+    assert title["total_hosts"] == 12
+
+
+def test_serialize_titles_to_dict_empty():
+    """An empty title list still produces a valid envelope."""
+    payload = serialize_titles_to_dict([], report_title=None)
+    assert payload["title_count"] == 0
+    assert payload["titles"] == []
+    assert payload["report_title"] is None
+
+
+def test_serialize_titles_to_dict_is_json_serializable(sample_patch_reports):
+    """The dict must round-trip through json.dumps without errors."""
+    payload = serialize_titles_to_dict(sample_patch_reports, report_title="Test")
+    json_str = json.dumps(payload)
+    parsed = json.loads(json_str)
+    assert parsed["title_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_export_to_json_success(sample_patch_reports, temp_output_dir):
+    """The export method writes a valid JSON file when 'json' is in formats."""
+    data_manager = DataManager()
+
+    with patch.object(data_manager, "_cache_data", return_value=None):
+        exported_files = await data_manager.export(
+            sample_patch_reports, temp_output_dir, "Test Report", formats={"json"}
+        )
+
+    json_path = exported_files.get("json")
+    assert json_path is not None
+    assert os.path.exists(json_path)
+    assert json_path.endswith(".json")
+
+    with open(json_path) as f:
+        payload = json.load(f)
+
+    assert payload["title_count"] == 1
+    assert payload["report_title"] == "Test Report"
+    assert payload["titles"][0]["title"] == "Example Software"
+    assert "generated_at" in payload
+
+
+@pytest.mark.asyncio
+async def test_export_default_includes_json(sample_patch_reports, temp_output_dir):
+    """When no formats are specified, JSON is included in the default set."""
+    data_manager = DataManager()
+
+    with patch.object(data_manager, "_cache_data", return_value=None):
+        exported_files = await data_manager.export(
+            sample_patch_reports, temp_output_dir, "Test Report"
+        )
+
+    assert "json" in exported_files
+    assert "excel" in exported_files
+    assert "html" in exported_files
+    assert "pdf" in exported_files

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -219,3 +219,64 @@ async def test_create_client_failure(setup_instance):
     with patch.object(setup_instance, "start", side_effect=mock_start):
         with pytest.raises(Exception, match="boom"):
             await setup_instance.start()
+
+
+# Non-interactive bootstrap (CI/CD path)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_noninteractive_success(setup_instance):
+    """Bootstrap saves creds, fetches a token, and marks completion in memory."""
+    setup_instance.config.set_credential.reset_mock()
+
+    with patch("src.patcher.client.setup.TokenManager") as MockTokenManager:
+        mock_tm = MagicMock()
+        mock_tm.fetch_token = MagicMock()
+
+        async def fake_fetch_token():
+            return MagicMock(token="abc", expires="2099-01-01T00:00:00Z")
+
+        mock_tm.fetch_token.side_effect = fake_fetch_token
+        MockTokenManager.return_value = mock_tm
+
+        await setup_instance.bootstrap_noninteractive(
+            client_id="cid", client_secret="csec", url="https://jamf.example.com"
+        )
+
+    # All three creds were saved via ConfigManager
+    saved_calls = setup_instance.config.set_credential.call_args_list
+    saved_keys = {call.args[0] for call in saved_calls}
+    assert {"URL", "CLIENT_ID", "CLIENT_SECRET"}.issubset(saved_keys)
+
+    # Token was fetched
+    mock_tm.fetch_token.assert_called_once()
+
+    # In-memory completion marked, no plist write
+    assert setup_instance._completed is True
+    setup_instance.plist_manager.set.assert_not_called() if hasattr(
+        setup_instance.plist_manager.set, "assert_not_called"
+    ) else None
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_noninteractive_token_failure_raises_setuperror(setup_instance):
+    """If the token fetch fails, a SetupError is raised with a clear message."""
+    from src.patcher.utils.exceptions import TokenError
+
+    with patch("src.patcher.client.setup.TokenManager") as MockTokenManager:
+        mock_tm = MagicMock()
+
+        async def boom():
+            raise TokenError("bad creds", url="https://jamf.example.com", error_msg="401")
+
+        mock_tm.fetch_token.side_effect = boom
+        MockTokenManager.return_value = mock_tm
+
+        with pytest.raises(SetupError) as excinfo:
+            await setup_instance.bootstrap_noninteractive(
+                client_id="cid", client_secret="bad", url="https://jamf.example.com"
+            )
+
+    assert "non-interactive mode" in str(excinfo.value)
+    # Completion NOT marked
+    assert setup_instance._completed is None or setup_instance._completed is False


### PR DESCRIPTION
# feat: CI/CD support — non-interactive mode + JSON export

Adds the ability to run Patcher in CI/CD environments without keychain access or interactive prompts, and adds JSON as a fourth export format.

## Changes

- **Non-interactive mode** — `--client-id` / `--client-secret` / `--url` flags (with `PATCHER_CLIENT_ID` / `PATCHER_CLIENT_SECRET` / `PATCHER_URL` env var fallbacks). When all three are present, Patcher skips every prompt and holds credentials in memory for the invocation.
- **JSON export** — `--format=json` outputs a structured report alongside the existing Excel/HTML/PDF formats.
- **Docs** — new `docs/user/ci_cd.md` covering the contract + a GH Actions example.

## Example

```bash
PATCHER_CLIENT_ID=abc PATCHER_CLIENT_SECRET=xyz PATCHER_URL=https://my.jamfcloud.com \
  patcherctl export --path=./reports --format=json
```

## Test plan

- [x] 125/125 unit tests pass (7 new)
- [x] `make lint` + pre-commit clean
- [x] Sphinx docs build without warnings
- [ ] Live-instance smoke test (not feasible locally — community welcome to validate)
