### PR TITLE
fix(setup): await click.prompt + loop on invalid choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.4.1] - 2026-05-12
+### Fixed
+- **`RecursionError` during setup on Python 3.14 / asyncclick 8.2+** ([#58](https://github.com/liquidz00/Patcher/issues/58)). `click.prompt` became an `async def` in asyncclick 8.2; calling it without `await` returns an un-awaited coroutine that never matches the expected setup-type choice, falls into the "Invalid choice" branch, and recursively re-invokes `Setup.start()` until the Python stack is exhausted. Every `click.prompt` call site in `Setup`, `UIConfigManager`, and the `reset` command now uses `await`. `Setup.prompt_credentials`, `UIConfigManager.setup_ui`/`configure_font`/`configure_logo` are now `async def` to support the awaitable prompts. The invalid-choice path in `Setup.start()` is also refactored from recursive retry to a `while True` loop so the same recursion footgun can't recur from any future input-validation regression.
+
 ## [v2.4.0] - 2026-05-04
 ### Added
 - JSON output format for exported patch reports (`--format=json`). Suitable for machine-consumable pipelines and downstream automation.

--- a/src/patcher/__about__.py
+++ b/src/patcher/__about__.py
@@ -1,2 +1,2 @@
 __title__ = "patcher"
-__version__ = "2.4.0"
+__version__ = "2.4.1"

--- a/src/patcher/cli.py
+++ b/src/patcher/cli.py
@@ -299,7 +299,7 @@ async def reset(ctx: click.Context, kind: str, credential: str | None) -> None:
             log.info("Resetting UI elements...")
             if ui_config.reset_config():
                 # Only prompt to setup UI if reset_config was successful
-                ui_config.setup_ui()
+                await ui_config.setup_ui()
         elif kind.lower() == "creds":
             log.info(f"Resetting credentials... (specific: {credential if credential else 'all'})")
 
@@ -308,20 +308,20 @@ async def reset(ctx: click.Context, kind: str, credential: str | None) -> None:
             # entries first.
             match credential:
                 case "url":
-                    new_url = click.prompt("Enter your Jamf Pro URL")
+                    new_url = await click.prompt("Enter your Jamf Pro URL")
                     config.set_credential("URL", new_url)
                 case "client_id":
-                    new_client_id = click.prompt("Enter your API Client ID")
+                    new_client_id = await click.prompt("Enter your API Client ID")
                     config.set_credential("CLIENT_ID", new_client_id)
                 case "client_secret":
-                    new_client_secret = click.prompt("Enter your API Client Secret")
+                    new_client_secret = await click.prompt("Enter your API Client Secret")
                     config.set_credential("CLIENT_SECRET", new_client_secret)
                 case None:
                     log.info("Attempting to delete all credentials from keychain...")
                     cred_map = {
-                        "URL": click.prompt("Enter your Jamf Pro URL"),
-                        "CLIENT_ID": click.prompt("Enter your API Client ID"),
-                        "CLIENT_SECRET": click.prompt("Enter your API Client Secret"),
+                        "URL": await click.prompt("Enter your Jamf Pro URL"),
+                        "CLIENT_ID": await click.prompt("Enter your API Client ID"),
+                        "CLIENT_SECRET": await click.prompt("Enter your API Client Secret"),
                     }
                     for k, v in cred_map.items():
                         config.set_credential(k, v)

--- a/src/patcher/client/setup.py
+++ b/src/patcher/client/setup.py
@@ -209,7 +209,7 @@ class Setup:
         for key, value in creds.items():
             self.config.set_credential(key, value)
 
-    def prompt_credentials(self, setup_type: SetupType) -> dict:
+    async def prompt_credentials(self, setup_type: SetupType) -> dict:
         """
         Prompt for credentials based on the credential type.
 
@@ -221,15 +221,15 @@ class Setup:
         self.log.info(f"Prompting user for {setup_type.value} credentials.")
         if setup_type == SetupType.STANDARD:
             return {
-                "URL": click.prompt("Enter your Jamf Pro URL"),
-                "USERNAME": click.prompt("Enter your Jamf Pro username"),
-                "PASSWORD": click.prompt("Enter your Jamf Pro password", hide_input=True),
+                "URL": await click.prompt("Enter your Jamf Pro URL"),
+                "USERNAME": await click.prompt("Enter your Jamf Pro username"),
+                "PASSWORD": await click.prompt("Enter your Jamf Pro password", hide_input=True),
             }
         elif setup_type == SetupType.SSO:
             return {
-                "URL": click.prompt("Enter your Jamf Pro URL"),
-                "CLIENT_ID": click.prompt("Enter your API Client ID"),
-                "CLIENT_SECRET": click.prompt("Enter your API Client Secret"),
+                "URL": await click.prompt("Enter your Jamf Pro URL"),
+                "CLIENT_ID": await click.prompt("Enter your API Client ID"),
+                "CLIENT_SECRET": await click.prompt("Enter your API Client Secret"),
             }
 
     def validate_creds(
@@ -355,7 +355,7 @@ class Setup:
         :type setup_type: :class:`~patcher.client.setup.SetupType`
         :raises SetupError: If credentials are missing or a token cannot be obtained.
         """
-        creds = self.prompt_credentials(setup_type)
+        creds = await self.prompt_credentials(setup_type)
         self.prompt_installomator()
         if setup_type == SetupType.STANDARD:
             self.validate_creds(creds, ("USERNAME", "PASSWORD", "URL"), SetupType.STANDARD)
@@ -430,7 +430,7 @@ class Setup:
         :type _setup_type: :class:`~patcher.client.setup.SetupType`
         """
         await animator.stop()
-        self.ui_config.setup_ui()
+        await self.ui_config.setup_ui()
         self.state_manager.save_stage(SetupStage.COMPLETED)
         self.stage = SetupStage.COMPLETED
         self._mark_completion(value=True)
@@ -523,19 +523,27 @@ class Setup:
         elif not self.state_manager.state_path.exists():
             self._greet()
 
-        choice = click.prompt(
-            "Choose setup method (1: Standard setup, 2: SSO setup)", type=int, default=1
-        )
-
-        if choice in setup_type_map:
-            while self.stage != SetupStage.COMPLETED:
-                handler = self.stage_map.get(self.stage)
-                if handler is None:
-                    raise SetupError("Missing handler for saved stage", stage=self.stage)
-                await handler(animator, setup_type_map[choice])
-        else:
+        # Loop until a valid setup type is chosen. Previously this branch
+        # recursively called ``self.start()`` on invalid input, which both lost
+        # the ``animator``/``fresh`` arguments and blew the Python stack with
+        # ~1000 frames if the prompt produced a non-int (e.g. asyncclick's
+        # async-aware ``prompt`` returning a coroutine instead of the value
+        # because the caller didn't ``await`` it).
+        while True:
+            choice = await click.prompt(
+                "Choose setup method (1: Standard setup, 2: SSO setup)",
+                type=int,
+                default=1,
+            )
+            if choice in setup_type_map:
+                break
             click.echo(click.style("Invalid choice, please choose 1 or 2", fg="red"))
-            await self.start()
+
+        while self.stage != SetupStage.COMPLETED:
+            handler = self.stage_map.get(self.stage)
+            if handler is None:
+                raise SetupError("Missing handler for saved stage", stage=self.stage)
+            await handler(animator, setup_type_map[choice])
 
     def reset_setup(self) -> bool:
         """

--- a/src/patcher/client/ui_manager.py
+++ b/src/patcher/client/ui_manager.py
@@ -175,7 +175,7 @@ class UIConfigManager:
             self.log.error(f"Failed resetting UI-config settings. Details: {e}")
             return False
 
-    def setup_ui(self):
+    async def setup_ui(self):
         """
         Guides the user through configuring UI settings for PDF reports, including header/footer text,
         font choices, and an optional branding logo.
@@ -188,17 +188,20 @@ class UIConfigManager:
         defaults = UIDefaults()
         self._download_fonts()
 
+        header_text = await click.prompt(
+            "Enter Header Text for PDF reports",
+            default=self.config.get(UIConfigKeys.HEADER.value, defaults.header_text),
+            show_default=True,
+        )
+        footer_text = await click.prompt(
+            "Enter Footer Text for PDF reports",
+            default=self.config.get(UIConfigKeys.FOOTER.value, defaults.footer_text),
+            show_default=True,
+        )
+
         settings = {
-            UIConfigKeys.HEADER.value: click.prompt(
-                "Enter Header Text for PDF reports",
-                default=self.config.get(UIConfigKeys.HEADER.value, defaults.header_text),
-                show_default=True,
-            ),
-            UIConfigKeys.FOOTER.value: click.prompt(
-                "Enter Footer Text for PDF reports",
-                default=self.config.get(UIConfigKeys.FOOTER.value, defaults.footer_text),
-                show_default=True,
-            ),
+            UIConfigKeys.HEADER.value: header_text,
+            UIConfigKeys.FOOTER.value: footer_text,
             UIConfigKeys.FONT_NAME.value: "Assistant",
             UIConfigKeys.REG_FONT_PATH.value: str(self._get_font_paths()["regular"]),
             UIConfigKeys.BOLD_FONT_PATH.value: str(self._get_font_paths()["bold"]),
@@ -206,19 +209,19 @@ class UIConfigManager:
         }
 
         if click.confirm("Would you like to use a custom font?", default=False):
-            settings.update(self.configure_font())
+            settings.update(await self.configure_font())
 
         if click.confirm(
             "Would you like to use a custom logo in your exported PDF reports?", default=False
         ):
-            settings[UIConfigKeys.LOGO_PATH.value] = self.configure_logo()
+            settings[UIConfigKeys.LOGO_PATH.value] = await self.configure_logo()
 
         if click.confirm(
             "Would you like to use a custom header color in your exported HTML reports?",
             default=False,
         ):
             header_color = str(
-                click.prompt("Enter header color value (Hex format)")
+                await click.prompt("Enter header color value (Hex format)")
             )  # default set at model level
             if not header_color.startswith("#"):
                 header_color = f"#{header_color}"
@@ -226,7 +229,7 @@ class UIConfigManager:
 
         self.config = settings
 
-    def configure_font(self) -> dict[str, str]:
+    async def configure_font(self) -> dict[str, str]:
         """
         Allows the user to specify a custom font or use the default provided by the application.
         The chosen fonts are copied to the appropriate directory for use in PDF report generation.
@@ -234,9 +237,9 @@ class UIConfigManager:
         :return: A dictionary containing the font name, regular font path, and bold font path.
         :rtype: dict[str, str]
         """
-        font_name = click.prompt("Enter custom font name", default="CustomFont")
-        regular_src = Path(click.prompt("Enter the path to the regular font file"))
-        bold_src = Path(click.prompt("Enter the path to the bold font file"))
+        font_name = await click.prompt("Enter custom font name", default="CustomFont")
+        regular_src = Path(await click.prompt("Enter the path to the regular font file"))
+        bold_src = Path(await click.prompt("Enter the path to the bold font file"))
 
         regular_dest, bold_dest = self._get_font_paths()["regular"], self._get_font_paths()["bold"]
         self._copy_file(regular_src, regular_dest)
@@ -248,7 +251,7 @@ class UIConfigManager:
             UIConfigKeys.BOLD_FONT_PATH.value: str(bold_dest),
         }
 
-    def configure_logo(self) -> str:
+    async def configure_logo(self) -> str:
         """
         Configures the logo file for PDF reports based on user input.
 
@@ -262,7 +265,7 @@ class UIConfigManager:
         :raises PatcherError: If the provided logo fails pillow validation.
         :raises PatcherError: If the logo file could not be copied to the destination path.
         """
-        logo_src = Path(click.prompt("Enter the path to the logo file"))
+        logo_src = Path(await click.prompt("Enter the path to the logo file"))
         if not logo_src.exists():
             raise SetupError(
                 "The specified logo path does not exist, please check the path and try again.",

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from src.patcher.client.setup import Setup, SetupStage, SetupType
@@ -47,28 +47,69 @@ def test_setup_type_enum():
     assert SetupType.SSO.value == "sso"
 
 
-def testprompt_credentials_standard(setup_instance):
-    # Mock the entire prompt_credentials method to avoid asyncclick complexity
+@pytest.mark.asyncio
+async def testprompt_credentials_standard(setup_instance):
+    # Mock the entire prompt_credentials method to avoid asyncclick complexity.
+    # ``prompt_credentials`` is async because it awaits ``click.prompt`` (which
+    # is an ``async def`` in asyncclick 8.2+).
     expected_creds = {
         "URL": "https://example.com",
         "USERNAME": "username",
         "PASSWORD": "password",
     }
-    with patch.object(setup_instance, "prompt_credentials", return_value=expected_creds):
-        creds = setup_instance.prompt_credentials(SetupType.STANDARD)
+    with patch.object(setup_instance, "prompt_credentials", AsyncMock(return_value=expected_creds)):
+        creds = await setup_instance.prompt_credentials(SetupType.STANDARD)
         assert creds == expected_creds
 
 
-def testprompt_credentials_sso(setup_instance):
-    # Mock the entire prompt_credentials method to avoid asyncclick complexity
+@pytest.mark.asyncio
+async def testprompt_credentials_sso(setup_instance):
     expected_creds = {
         "URL": "https://example.com",
         "CLIENT_ID": "client_id",
         "CLIENT_SECRET": "client_secret",
     }
-    with patch.object(setup_instance, "prompt_credentials", return_value=expected_creds):
-        creds = setup_instance.prompt_credentials(SetupType.SSO)
+    with patch.object(setup_instance, "prompt_credentials", AsyncMock(return_value=expected_creds)):
+        creds = await setup_instance.prompt_credentials(SetupType.SSO)
         assert creds == expected_creds
+
+
+def test_methods_with_click_prompt_are_async():
+    """Regression for #58 — ``click.prompt`` is ``async def`` in asyncclick 8.2+;
+    methods that call it must be ``async def`` so they can ``await`` it.
+
+    The original bug was that ``Setup.prompt_credentials`` and
+    ``UIConfigManager.setup_ui``/``configure_font``/``configure_logo`` called
+    ``click.prompt`` synchronously, producing un-awaited coroutines that
+    silently broke setup with ``RuntimeWarning`` and then ``RecursionError``.
+    """
+    import inspect
+
+    from src.patcher.client.ui_manager import UIConfigManager
+
+    for method in (
+        Setup.prompt_credentials,
+        UIConfigManager.setup_ui,
+        UIConfigManager.configure_font,
+        UIConfigManager.configure_logo,
+    ):
+        assert inspect.iscoroutinefunction(method), (
+            f"{method.__qualname__} calls click.prompt and must be async. See issue #58."
+        )
+
+
+def test_setup_start_does_not_self_recurse():
+    """Regression for #58 — ``Setup.start()`` must retry invalid input via a loop,
+    not by calling itself recursively. The recursion was the mechanism that
+    turned the unawaited-coroutine bug into a stack-exhausting RecursionError.
+    """
+    import inspect
+
+    source = inspect.getsource(Setup.start)
+    assert "await self.start(" not in source, (
+        "Setup.start() must not recursively call itself on invalid input — "
+        "use a `while True` loop instead. See issue #58."
+    )
 
 
 def testvalidate_creds_success(setup_instance):


### PR DESCRIPTION
## Summary

- Adds `await` to every `click.prompt` call site (21 across `cli.py`, `client/setup.py`, `client/ui_manager.py`)
- Converts the methods that wrap them to `async def` so the awaits compile (`Setup.prompt_credentials`, `UIConfigManager.setup_ui`/`configure_font`/`configure_logo`)
- Replaces the recursive retry in `Setup.start()` with a `while True` loop so the same class of bug can't blow the stack again
- Adds two regression tests that lock in the async signatures and the absence of self-recursion

Fixes #58.

## Root cause

`click.prompt` is `async def` in asyncclick 8.2+. Calling it synchronously returns a never-awaited coroutine, which silently bypasses the integer-comparison check in `Setup.start()`'s setup-type prompt, falls into the "Invalid choice" branch, and recursively re-invokes `Setup.start()` until Python's recursion limit hits at ~1000 frames.

End users on Python 3.14 see:

```
Invalid choice, please choose 1 or 2
❌ RecursionError: maximum recursion depth exceeded
<sys>:0: RuntimeWarning: coroutine 'prompt' was never awaited
```

Patcher's CI matrix tops out at Python 3.13 and mocks `click.prompt` directly in unit tests, so the regression went undetected. `click.confirm` is still synchronous in asyncclick 8.3 — those call sites are unchanged.

Bumps `__version__` to `2.4.1`. CHANGELOG entry under that version.

## Test plan

- [x] `make test` — 127 unit tests pass (was 125 before the two new regression tests)
- [x] `make lint` — clean
- [ ] Smoke test on Python 3.14 — install from the branch, run `patcherctl` on a fresh machine, confirm setup prompt accepts choice without RecursionError
- [ ] Verify against asyncclick 8.3.0.7 (current pinned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
